### PR TITLE
Switch to Rotation_Vector sensor & reimplement sensor data interpretation with quaternion-based calculations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,11 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'de.mobilej.unmock:UnMockPlugin:0.1.1'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=1.0.2
-VERSION_CODE=37
+VERSION_NAME=1.1.0
+VERSION_CODE=42
 GROUP=com.nvanbenschoten.motion
 
 POM_DESCRIPTION=An Android library allowing images to exhibit a parallax effect

--- a/motion-sample/src/main/java/com/nvanbenschoten/motion/motion_sample/ParallaxActivity.java
+++ b/motion-sample/src/main/java/com/nvanbenschoten/motion/motion_sample/ParallaxActivity.java
@@ -18,7 +18,21 @@ import android.widget.Switch;
 
 import com.nvanbenschoten.motion.ParallaxImageView;
 
-
+/*
+ * Copyright 2014 Nathan VanBenschoten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 public class ParallaxActivity extends Activity {
 
     @Override
@@ -73,9 +87,6 @@ public class ParallaxActivity extends Activity {
         public void onViewCreated(View view, Bundle savedInstanceState) {
             super.onViewCreated(view, savedInstanceState);
 
-            // Adjust the Parallax forward tilt adjustment
-            mBackground.setForwardTiltOffset(.35f);
-
             // Set SeekBar to change parallax intensity
             mSeekBar.setMax(10);
             mSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
@@ -90,15 +101,16 @@ public class ParallaxActivity extends Activity {
                 @Override
                 public void onStopTrackingTouch(SeekBar seekBar) { }
             });
-            mSeekBar.setProgress(1);
+            mSeekBar.setProgress(2);
         }
 
         @Override
         public void onResume() {
             super.onResume();
 
-            if (mParallaxSet)
+            if (mParallaxSet) {
                 mBackground.registerSensorManager();
+            }
         }
 
         @Override

--- a/motion-sample/src/main/res/layout/activity_parallax.xml
+++ b/motion-sample/src/main/res/layout/activity_parallax.xml
@@ -1,4 +1,5 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/motion/build.gradle
+++ b/motion/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
+apply plugin: 'de.mobilej.unmock'
 
 android {
     compileSdkVersion 22
     buildToolsVersion '22.0.1'
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 9
         targetSdkVersion 22
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
@@ -24,6 +25,15 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
+}
+
+unMock {
+    allAndroid = 'https://oss.sonatype.org/content/groups/public/org/robolectric/android-all/5.0.0_r2-robolectric-1/android-all-5.0.0_r2-robolectric-1.jar'
+
+    keep = [
+            "android.hardware.SensorEvent",
+            "android.hardware.SensorManager",
+    ]
 }
 
 apply from: 'https://raw.githubusercontent.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/motion/src/main/res/values/attrs.xml
+++ b/motion/src/main/res/values/attrs.xml
@@ -3,7 +3,6 @@
     <declare-styleable name="ParallaxImageView">
         <attr name="intensity" format="float"/>
         <attr name="tiltSensitivity" format="float"/>
-        <attr name="forwardTiltOffset" format="float"/>
         <attr name="scaledIntensity" format="boolean"/>
     </declare-styleable>
 </resources>

--- a/motion/src/test/java/com/nvanbenschoten/motion/SensorInterpreterTest.java
+++ b/motion/src/test/java/com/nvanbenschoten/motion/SensorInterpreterTest.java
@@ -9,12 +9,27 @@ import android.view.WindowManager;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.Constructor;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
+/*
+ * Copyright 2014 Nathan VanBenschoten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 public class SensorInterpreterTest {
 
     private final float ACCEPTABLE_FLOAT_DELTA = 0.0001f;
@@ -23,103 +38,83 @@ public class SensorInterpreterTest {
     public void testInterpretSensorEventPortraitWithNoOffset() throws Exception {
         SensorInterpreter sensorInterpreter = new SensorInterpreter();
         sensorInterpreter.setTiltSensitivity(2);
-        sensorInterpreter.setForwardTiltOffset(0);
+        sensorInterpreter.setTargetVector(new float[]{0.5f, 0.6f, 0.7f});
 
         Context context = mockRotationContext(Surface.ROTATION_0);
-        SensorEvent event = mockSensorEvent(3);
-        event.values[0] = 10f;
-        event.values[1] = 25f;
-        event.values[2] = 40f;
+        SensorEvent event = mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
-        assertArrayEquals(new float[]{10f, -0.55555f, -0.88888f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
+        assertArrayEquals(new float[]{-0.19003f, 0.21814f, 0.02382f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
     }
 
     @Test
     public void testInterpretSensorEventLandscapeRightWithNoOffset() throws Exception {
         SensorInterpreter sensorInterpreter = new SensorInterpreter();
         sensorInterpreter.setTiltSensitivity(2);
-        sensorInterpreter.setForwardTiltOffset(0);
+        sensorInterpreter.setTargetVector(new float[]{0.5f, 0.6f, 0.7f});
 
         Context context = mockRotationContext(Surface.ROTATION_90);
-        SensorEvent event = mockSensorEvent(3);
-        event.values[0] = 10f;
-        event.values[1] = 25f;
-        event.values[2] = 40f;
+        SensorEvent event = mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
-        assertArrayEquals(new float[]{10f, 0.88888f,  -0.55555f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
+        assertArrayEquals(new float[]{1.0f, 0.04103f, -0.12279f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
     }
 
     @Test
     public void testInterpretSensorEventLandscapeLeftWithNoOffset() throws Exception {
         SensorInterpreter sensorInterpreter = new SensorInterpreter();
         sensorInterpreter.setTiltSensitivity(2);
-        sensorInterpreter.setForwardTiltOffset(0);
+        sensorInterpreter.setTargetVector(new float[]{0.5f, 0.6f, 0.7f});
 
         Context context = mockRotationContext(Surface.ROTATION_270);
-        SensorEvent event = mockSensorEvent(3);
-        event.values[0] = 10f;
-        event.values[1] = 25f;
-        event.values[2] = 40f;
+        SensorEvent event = mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
-        assertArrayEquals(new float[]{10f, -0.88888f, 0.55555f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
+        assertArrayEquals(new float[]{-0.92730f, -0.04103f, 0.12279f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
     }
 
     @Test
     public void testInterpretSensorEventUpsideDownWithNoOffset() throws Exception {
         SensorInterpreter sensorInterpreter = new SensorInterpreter();
         sensorInterpreter.setTiltSensitivity(2);
-        sensorInterpreter.setForwardTiltOffset(0);
+        sensorInterpreter.setTargetVector(new float[]{0.5f, 0.6f, 0.7f});
 
         Context context = mockRotationContext(Surface.ROTATION_180);
-        SensorEvent event = mockSensorEvent(3);
-        event.values[0] = 10f;
-        event.values[1] = 25f;
-        event.values[2] = 40f;
+        SensorEvent event = mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
-        assertArrayEquals(new float[]{10f, 0.55555f, 0.88888f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
-    }
-
-    @Test
-    public void testInterpretSensorEventPortraitWithOffset() throws Exception {
-        SensorInterpreter sensorInterpreter = new SensorInterpreter();
-        sensorInterpreter.setTiltSensitivity(2);
-        sensorInterpreter.setForwardTiltOffset(0.1f);
-
-        Context context = mockRotationContext(Surface.ROTATION_0);
-        SensorEvent event = mockSensorEvent(3);
-        event.values[0] = 10f;
-        event.values[1] = 25f;
-        event.values[2] = 40f;
-
-        float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
-
-        assertArrayEquals(new float[]{10f, -0.75555f, -0.88888f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
+        assertArrayEquals(new float[]{1.0f, -0.21815f, -0.02382f}, interpreted, ACCEPTABLE_FLOAT_DELTA);
     }
 
     @Test
     public void testInterpretSensorClampValues() throws Exception {
         SensorInterpreter sensorInterpreter = new SensorInterpreter();
         sensorInterpreter.setTiltSensitivity(1.5f);
-        sensorInterpreter.setForwardTiltOffset(0);
+        sensorInterpreter.setTargetVector(new float[]{0f, 0f, 0f});
 
-        Context context = mockRotationContext(Surface.ROTATION_180);
-        SensorEvent event = mockSensorEvent(3);
-        event.values[0] = 10f;
-        event.values[1] = 65f;
-        event.values[2] = -80f;
+        Context context = mockRotationContext(Surface.ROTATION_0);
+        SensorEvent event = mockSensorEvent(new float[]{3.1f, 0f, 3.1f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
-        assertEquals("positive numbers over 1 clamp to 1", 1f, interpreted[1], ACCEPTABLE_FLOAT_DELTA);
-        assertEquals("negative numbers under -1 clamp to -1", -1f, interpreted[2], ACCEPTABLE_FLOAT_DELTA);
+        assertEquals("positive numbers over 1 clamp to 1", 1, interpreted[0], ACCEPTABLE_FLOAT_DELTA);
+        assertEquals("negative numbers under -1 clamp to -1", -1, interpreted[2], ACCEPTABLE_FLOAT_DELTA);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetInvalidTiltSensitivity() throws Exception {
+        SensorInterpreter sensorInterpreter = new SensorInterpreter();
+        sensorInterpreter.setTiltSensitivity(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetNegativeTiltSensitivity() throws Exception {
+        SensorInterpreter sensorInterpreter = new SensorInterpreter();
+        sensorInterpreter.setTiltSensitivity(-1);
     }
 
     private Context mockRotationContext(int rotation) {
@@ -134,12 +129,12 @@ public class SensorInterpreterTest {
         return context;
     }
 
-    private SensorEvent mockSensorEvent(int size) throws Exception {
-        SensorEvent event = Mockito.mock(SensorEvent.class);
+    private SensorEvent mockSensorEvent(float[] values) throws Exception {
+        Constructor<SensorEvent> c = SensorEvent.class.getDeclaredConstructor(int.class);
+        c.setAccessible(true);
 
-        Field valuesField = SensorEvent.class.getField("values");
-        valuesField.setAccessible(true);
-        valuesField.set(event, new float[size]);
+        SensorEvent event = c.newInstance(values.length);
+        System.arraycopy(values, 0, event.values, 0, values.length);
 
         return event;
     }


### PR DESCRIPTION
In order to resolve #4, a number of changes have been made to improve the accuracy and stability of both the collection and interpretation of sensor data. 

Sensor overhaul:
----

First, the library has switched from using the deprecated ***Orientation*** sensor to using the newer ***Rotation_Vector*** fusion sensor. This has forced the library to increase its minSDK from 8 to 9, but should greatly increase the accuracy the reliability of the sensor data.

Second, the library has overhauled data interpretation calculations. Instead of using absolute orientation to determine relative tilt, it now grabs an ***initial target rotation matrix*** to base all rotation changes off of. The angle change between current sensor readings, again as a rotation matrix, and this initial reading are now used to determine offsets for all tilt values. By using rotation matrices for all calculations, the issue of gimbal lock should be eliminated and the parallax effect should act correctly at all orientations.

Potential breaking changes:
----
- Minimum SDK version bumped from ***8 to 9*** (unfortunately needed to use the Rotation_Vector sensor)
- forwardTiltOffset attribute removed because calculations are all relative-based
- tiltSensitivity may need to be increased slightly (roughly 2x) to have the same amount of effect it used to have