### PR TITLE
Truncate RotationVector in SensorInterpreter to avoid Samsung getRotationMatrixFromVector bug

### DIFF
--- a/motion/build.gradle
+++ b/motion/build.gradle
@@ -23,6 +23,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
+    compile 'com.android.support:support-annotations:23.0.0'
+
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
 }

--- a/motion/src/main/java/com/nvanbenschoten/motion/ParallaxImageView.java
+++ b/motion/src/main/java/com/nvanbenschoten/motion/ParallaxImageView.java
@@ -116,7 +116,7 @@ public class ParallaxImageView extends ImageView implements SensorEventListener 
     @Override
     public void onSensorChanged(SensorEvent event) {
         if (mSensorInterpreter == null) return;
-        final float [] vectors = mSensorInterpreter.interpretSensorEvent(getContext(), event);
+        final float[] vectors = mSensorInterpreter.interpretSensorEvent(getContext(), event);
 
         // Return if interpretation of data failed
         if (vectors == null) return;
@@ -156,6 +156,7 @@ public class ParallaxImageView extends ImageView implements SensorEventListener 
     /**
      * Unregisters the ParallaxImageView's SensorManager. Should be called in onPause from
      * an Activity or Fragment to avoid continuing sensor usage.
+     *
      * @param resetTranslation if the image translation should be reset to the origin
      */
     public void unregisterSensorManager(boolean resetTranslation) {

--- a/motion/src/test/java/com/nvanbenschoten/motion/SamsungRotationMatrixBugTest.java
+++ b/motion/src/test/java/com/nvanbenschoten/motion/SamsungRotationMatrixBugTest.java
@@ -1,0 +1,47 @@
+package com.nvanbenschoten.motion;
+
+import android.hardware.SensorEvent;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/*
+ * Copyright 2015 Nathan VanBenschoten
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class SamsungRotationMatrixBugTest {
+
+    @Test
+    public void testRotationVectorForEventWithoutAccuracyValue() throws Exception {
+        SensorInterpreter sensorInterpreter = new SensorInterpreter();
+        SensorEvent event = TestUtils.mockSensorEvent(new float[]{0.1f, 0.2f, 0.3f, 0.4f});
+
+        float[] rotationVector = sensorInterpreter.getRotationVectorFromSensorEvent(event);
+        assertNotNull(rotationVector);
+        assertTrue(rotationVector.length <= 4);
+    }
+
+    @Test
+    public void testRotationVectorForEventWithAccuracyValue() throws Exception {
+        SensorInterpreter sensorInterpreter = new SensorInterpreter();
+        SensorEvent event = TestUtils.mockSensorEvent(new float[]{0.1f, 0.2f, 0.3f, 0.4f, -1});
+
+        float[] rotationVector = sensorInterpreter.getRotationVectorFromSensorEvent(event);
+        assertNotNull(rotationVector);
+        assertTrue(rotationVector.length <= 4);
+    }
+
+}

--- a/motion/src/test/java/com/nvanbenschoten/motion/SensorInterpreterTest.java
+++ b/motion/src/test/java/com/nvanbenschoten/motion/SensorInterpreterTest.java
@@ -2,18 +2,12 @@ package com.nvanbenschoten.motion;
 
 import android.content.Context;
 import android.hardware.SensorEvent;
-import android.view.Display;
 import android.view.Surface;
-import android.view.WindowManager;
 
 import org.junit.Test;
-import org.mockito.Mockito;
-
-import java.lang.reflect.Constructor;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
 /*
  * Copyright 2014 Nathan VanBenschoten
@@ -40,8 +34,8 @@ public class SensorInterpreterTest {
         sensorInterpreter.setTiltSensitivity(2);
         sensorInterpreter.setTargetVector(new float[]{0.5f, 0.6f, 0.7f});
 
-        Context context = mockRotationContext(Surface.ROTATION_0);
-        SensorEvent event = mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
+        Context context = TestUtils.mockRotationContext(Surface.ROTATION_0);
+        SensorEvent event = TestUtils.mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
@@ -54,8 +48,8 @@ public class SensorInterpreterTest {
         sensorInterpreter.setTiltSensitivity(2);
         sensorInterpreter.setTargetVector(new float[]{0.5f, 0.6f, 0.7f});
 
-        Context context = mockRotationContext(Surface.ROTATION_90);
-        SensorEvent event = mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
+        Context context = TestUtils.mockRotationContext(Surface.ROTATION_90);
+        SensorEvent event = TestUtils.mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
@@ -68,8 +62,8 @@ public class SensorInterpreterTest {
         sensorInterpreter.setTiltSensitivity(2);
         sensorInterpreter.setTargetVector(new float[]{0.5f, 0.6f, 0.7f});
 
-        Context context = mockRotationContext(Surface.ROTATION_270);
-        SensorEvent event = mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
+        Context context = TestUtils.mockRotationContext(Surface.ROTATION_270);
+        SensorEvent event = TestUtils.mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
@@ -82,8 +76,8 @@ public class SensorInterpreterTest {
         sensorInterpreter.setTiltSensitivity(2);
         sensorInterpreter.setTargetVector(new float[]{0.5f, 0.6f, 0.7f});
 
-        Context context = mockRotationContext(Surface.ROTATION_180);
-        SensorEvent event = mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
+        Context context = TestUtils.mockRotationContext(Surface.ROTATION_180);
+        SensorEvent event = TestUtils.mockSensorEvent(new float[]{0.7f, 0.7f, 0.7f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
@@ -96,8 +90,8 @@ public class SensorInterpreterTest {
         sensorInterpreter.setTiltSensitivity(1.5f);
         sensorInterpreter.setTargetVector(new float[]{0f, 0f, 0f});
 
-        Context context = mockRotationContext(Surface.ROTATION_0);
-        SensorEvent event = mockSensorEvent(new float[]{3.1f, 0f, 3.1f});
+        Context context = TestUtils.mockRotationContext(Surface.ROTATION_0);
+        SensorEvent event = TestUtils.mockSensorEvent(new float[]{3.1f, 0f, 3.1f});
 
         float[] interpreted = sensorInterpreter.interpretSensorEvent(context, event);
 
@@ -115,28 +109,6 @@ public class SensorInterpreterTest {
     public void testSetNegativeTiltSensitivity() throws Exception {
         SensorInterpreter sensorInterpreter = new SensorInterpreter();
         sensorInterpreter.setTiltSensitivity(-1);
-    }
-
-    private Context mockRotationContext(int rotation) {
-        Display display = Mockito.mock(Display.class);
-        when(display.getRotation()).thenReturn(rotation);
-
-        WindowManager windowManager = Mockito.mock(WindowManager.class);
-        when(windowManager.getDefaultDisplay()).thenReturn(display);
-
-        Context context = Mockito.mock(Context.class);
-        when(context.getSystemService(Context.WINDOW_SERVICE)).thenReturn(windowManager);
-        return context;
-    }
-
-    private SensorEvent mockSensorEvent(float[] values) throws Exception {
-        Constructor<SensorEvent> c = SensorEvent.class.getDeclaredConstructor(int.class);
-        c.setAccessible(true);
-
-        SensorEvent event = c.newInstance(values.length);
-        System.arraycopy(values, 0, event.values, 0, values.length);
-
-        return event;
     }
 
 }

--- a/motion/src/test/java/com/nvanbenschoten/motion/TestUtils.java
+++ b/motion/src/test/java/com/nvanbenschoten/motion/TestUtils.java
@@ -1,0 +1,51 @@
+package com.nvanbenschoten.motion;
+
+import android.content.Context;
+import android.hardware.SensorEvent;
+import android.view.Display;
+import android.view.WindowManager;
+
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+
+import static org.mockito.Mockito.when;
+
+public class TestUtils {
+
+    /**
+     * Creates a mock {@link Context} with the given rotation.
+     *
+     * @param rotation the screens orientation
+     * @return the mock Context
+     */
+    public static Context mockRotationContext(int rotation) {
+        Display display = Mockito.mock(Display.class);
+        when(display.getRotation()).thenReturn(rotation);
+
+        WindowManager windowManager = Mockito.mock(WindowManager.class);
+        when(windowManager.getDefaultDisplay()).thenReturn(display);
+
+        Context context = Mockito.mock(Context.class);
+        when(context.getSystemService(Context.WINDOW_SERVICE)).thenReturn(windowManager);
+        return context;
+    }
+
+    /**
+     * Creates a mock {@link SensorEvent} with the provided values.
+     *
+     * @param values the values
+     * @return the mock SensorEvent
+     * @throws Exception
+     */
+    public static SensorEvent mockSensorEvent(float[] values) throws Exception {
+        Constructor<SensorEvent> c = SensorEvent.class.getDeclaredConstructor(int.class);
+        c.setAccessible(true);
+
+        SensorEvent event = c.newInstance(values.length);
+        System.arraycopy(values, 0, event.values, 0, values.length);
+
+        return event;
+    }
+
+}


### PR DESCRIPTION
Fix for #16 

SensorEvents' RotationVectors are now truncated to a maximum of 4 elements to avoid an [IllegalArgumentException](https://groups.google.com/forum/#!topic/android-developers/U3N9eL5BcJk) being thrown when the rotation vector (Not R, event though the exception says so!) is more than 4 elements on certain Samsung models. This fix was inspired by Chrome's [DeviceMotionAndOrientation](https://src.chromium.org/viewvc/chrome/trunk/src/content/public/android/java/src/org/chromium/content/browser/DeviceMotionAndOrientation.java?pathrev=246398).